### PR TITLE
Query names no longer appear in labelplacements.py output table

### DIFF
--- a/code/labelplacements.py
+++ b/code/labelplacements.py
@@ -32,6 +32,12 @@ required.add_argument('--labels', dest='labels', type=str, required=True,
                           'path to label dict in pickle format. '
                           'More than one space-separated path can be input')
                           )
+optional.add_argument('--query_labels', dest='query_labels', type=str, default=None,
+                      nargs='+',
+                      help=(
+                          'path to query label dict in pickle format. '
+                          'More than one space-separated path can be input')
+                          )
 optional.add_argument('--ref_clusters', dest='ref_clusters', type=str,
                       default=None,
                       help=(
@@ -69,7 +75,11 @@ if args.outdir is None:
 
 def main():
 
-    label_dict = DictMerger.fromPicklePaths(args.labels).merge()
+    ref_labels = DictMerger.fromPicklePaths(args.labels).merge()
+    if args.query_labels is not None:
+        query_labels = DictMerger.fromPicklePaths(args.query_labels).merge()
+    else:
+        query_labels = None
     outgroup_file_generated = False
     
     if args.outgroup is not None:
@@ -82,7 +92,7 @@ def main():
             else:
                 outgroup_file = args.outgroup
         else:
-            matched_labels = [f'{ref}\n' for ref in label_dict.keys() if args.outgroup in ref]
+            matched_labels = [f'{ref}\n' for ref in ref_labels.keys() if args.outgroup in ref]
             if not matched_labels:
                 raise ValueError('No matched labels for given outgroup pattern')
             outgroup_file = setDefaultOutputPath(args.jplace,
@@ -99,7 +109,8 @@ def main():
 
     assignLabelsToPlacements(
         jplace=args.jplace,
-        id_dict=label_dict,
+        ref_labels=ref_labels,
+        query_labels=query_labels,
         output_dir=args.outdir,
         output_prefix=args.prefix,
         only_best_hit=True,

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -75,6 +75,7 @@ python3 code/placesequences.py \
 python3 code/labelplacements.py \
  --jplace tests/test_results/epa_result.jplace \
  --labels tests/test_results/ref_database_id_dict.pickle \
+ --query_labels tests/test_results/query_cleaned_id_dict.pickle \
  --ref_clusters tests/test_data/clusters.tsv \
  --ref_cluster_scores tests/test_data/cluster_scores.tsv \
  --outgroup "out_" \


### PR DESCRIPTION
Fixes #69

A new argument added to labelplacements.py

--query_labels

which is optional and must be fed with a path to a pickle file containing a dictionary of short to long labels for query sequences